### PR TITLE
Update to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,5 +20,5 @@ inputs:
     default: ${{ github.token }}
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
#### What this PR does / why we need it:
Node 20 is being deprecated this year https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/